### PR TITLE
fix(tests): replace hardcoded 21000 gas constants for EIP-2780 compatibility (tests/osaka)

### DIFF
--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -17,6 +17,7 @@ from execution_testing import (
     Fork,
     Hash,
     NetworkWrappedTransaction,
+    RecipientType,
     Transaction,
     TransactionException,
 )
@@ -49,9 +50,12 @@ def tx_value() -> int:
 
 
 @pytest.fixture
-def tx_gas() -> int:
+def tx_gas(fork: Fork, tx_value: int) -> int:
     """Gas allocated to transactions sent during test."""
-    return 21_000
+    return fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=tx_value > 0,
+    )
 
 
 @pytest.fixture

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -697,14 +697,15 @@ def test_tx_gas_limit_cap_authorized_tx(
     ) + int(exceed_tx_gas_limit)
 
     # EIP-7702 authorization transaction cost:
-    # 21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 *
-    # access list storage key count + 2400 * access list address count + access
-    # list data cost + GAS_AUTH_PER_EMPTY_ACCOUNT_COST * authorization list
-    # length
+    # intrinsic gas base cost + calldata cost + access list
+    # storage key cost + access list address cost + access
+    # list data cost + GAS_AUTH_PER_EMPTY_ACCOUNT_COST *
+    # authorization list length
     #
-    # There is no calldata and no storage keys in this test case.
-    # However, each access-list address includes data bytes that may contribute
-    # additional cost depending on fork repricing.
+    # There is no calldata and no storage keys in this
+    # test case. Each access-list address includes data
+    # bytes that may contribute additional cost depending
+    # on fork repricing.
 
     auth_address = pre.deploy_contract(code=Op.STOP)
 

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -16,6 +16,7 @@ from execution_testing import (
     Header,
     Op,
     ParameterSet,
+    RecipientType,
     Transaction,
     add_kzg_version,
 )
@@ -50,9 +51,14 @@ def gas_spender_contract(pre: Alloc) -> Address:
 
 
 @pytest.fixture
-def tx_gas() -> int:
+def tx_gas(fork: Fork) -> int:
     """Gas limit for blob transactions sent during test."""
-    return 21_000
+    return (
+        fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.CONTRACT,
+        )
+        + 1_000
+    )
 
 
 @pytest.fixture
@@ -261,7 +267,10 @@ def parent_block_txs(
     blob_txs_execution_gas = sum(tx.gas_limit for tx in parent_block_blob_txs)
     assert blob_txs_execution_gas <= required_gas_used
     extra_tx_gas_limit = required_gas_used - blob_txs_execution_gas
-    assert extra_tx_gas_limit >= 21_000
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.CONTRACT,
+    )
+    assert extra_tx_gas_limit >= intrinsic_gas
 
     extra_tx = Transaction(
         sender=sender,

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -213,7 +213,7 @@ def get_block_rlp_size(
     header.gas_limit = ZeroPaddedHexNumber(block_gas_limit)
     header.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
 
-    total_gas = sum((tx.gas_limit or 21000) for tx in transactions)
+    total_gas = sum(tx.gas_limit for tx in transactions)
     header.gas_used = ZeroPaddedHexNumber(total_gas)
 
     # Calculate blob gas used if there are blob transactions


### PR DESCRIPTION
## Summary

- **fix(tests):** Use fork-aware intrinsic gas calculator in peerdas `test_get_blobs` — the hardcoded `21_000` was below the EIP-2780 intrinsic cost of 30,000 for value-to-empty-account, making every blob transaction invalid.
- **refactor(tests):** Replace hardcoded `21_000` in blob reserve price transition tests (`tx_gas` fixture and assertion) with calculator-derived values.
- **refactor(tests):** Remove dead `or 21000` fallback in block RLP limit test gas summation.
- **refactor(tests):** Generalize stale gas cost comment in tx gas limit cap test to be fork-independent.

## Test plan

- [x] `uvx tox -e static` passes after each commit.
- [x] `fill` the affected test modules to verify fixture generation succeeds.