### PR TITLE
fix(tests): make more Prague tests fork-aware for EIP-2780

### DIFF
--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
@@ -48,7 +48,8 @@ def test_system_contract_deployment(
     )
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     test_transaction_gas = intrinsic_gas_calculator(
-        calldata=withdrawal_request.calldata
+        calldata=withdrawal_request.calldata,
+        sends_value=True,
     )
 
     test_transaction = Transaction(

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Bytecode,
+    Fork,
     Op,
     Requests,
     Transaction,
@@ -87,6 +88,7 @@ def withdrawal_list_with_custom_fee(n: int) -> List[WithdrawalRequest]:  # noqa:
 )
 def test_extra_withdrawals(
     blockchain_test: BlockchainTestFiller,
+    fork: Fork,
     pre: Alloc,
     requests_list: List[WithdrawalRequest],
 ) -> None:
@@ -126,7 +128,9 @@ def test_extra_withdrawals(
     # prepare withdrawal senders
     withdrawal_request_transaction.update_pre(pre=pre)
     # get transaction list
-    txs: List[Transaction] = withdrawal_request_transaction.transactions()
+    txs: List[Transaction] = withdrawal_request_transaction.transactions(
+        _fork=fork
+    )
 
     blockchain_test(
         pre=pre,

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -911,7 +911,7 @@ def test_withdrawal_requests_negative(
         post={},
         blocks=[
             Block(
-                txs=sum((r.transactions() for r in requests), []),
+                txs=sum((r.transactions(_fork=fork) for r in requests), []),
                 header_verify=Header(
                     requests_hash=Requests(
                         *included_requests,

--- a/tests/prague/eip7251_consolidations/test_contract_deployment.py
+++ b/tests/prague/eip7251_consolidations/test_contract_deployment.py
@@ -48,7 +48,8 @@ def test_system_contract_deployment(
     )
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     test_transaction_gas = intrinsic_gas_calculator(
-        calldata=consolidation_request.calldata
+        calldata=consolidation_request.calldata,
+        sends_value=True,
     )
 
     test_transaction = Transaction(

--- a/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
+++ b/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Bytecode,
+    Fork,
     Op,
     Requests,
     Transaction,
@@ -87,6 +88,7 @@ def consolidation_list_with_custom_fee(n: int) -> List[ConsolidationRequest]:  #
 )
 def test_extra_consolidations(
     blockchain_test: BlockchainTestFiller,
+    fork: Fork,
     pre: Alloc,
     requests_list: List[ConsolidationRequest],
 ) -> None:
@@ -127,7 +129,9 @@ def test_extra_consolidations(
     # prepare consolidation senders
     consolidation_request_transaction.update_pre(pre=pre)
     # get transaction list
-    txs: List[Transaction] = consolidation_request_transaction.transactions()
+    txs: List[Transaction] = consolidation_request_transaction.transactions(
+        _fork=fork
+    )
 
     blockchain_test(
         pre=pre,

--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -152,14 +152,14 @@ def tx_data(
     E.g. Given a transaction with a single access list and a single storage
     key, its intrinsic gas cost (as of Prague fork) can be calculated as:
 
-    - 21,000 gas for the transaction
+    - Base intrinsic gas for the transaction (fork-dependent)
     - 2,400 gas for the access list
     - 1,900 gas for the storage key
     - 16 gas for each non-zero byte in the data
     - 4 gas for each zero byte in the data
 
     Its floor data gas cost can be calculated as:
-    - 21,000 gas for the transaction
+    - Base intrinsic gas for the transaction (fork-dependent)
     - 40 gas for each non-zero byte in the data
     - 10 gas for each zero byte in the data
 

--- a/tests/prague/eip7685_general_purpose_el_requests/conftest.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/conftest.py
@@ -9,6 +9,7 @@ from execution_testing import (
     BlockException,
     Bytes,
     EngineAPIError,
+    Fork,
     Header,
     Requests,
 )
@@ -80,6 +81,7 @@ def engine_api_error_code(
 @pytest.fixture
 def blocks(
     pre: Alloc,
+    fork: Fork,
     requests: List[
         DepositInteractionBase
         | WithdrawalRequestInteractionBase
@@ -115,7 +117,7 @@ def blocks(
         )
     return [
         Block(
-            txs=sum((r.transactions() for r in requests), []),
+            txs=sum((r.transactions(_fork=fork) for r in requests), []),
             header_verify=Header(requests_hash=valid_requests),
             requests=block_body_override_requests,
             exception=exception,

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -795,7 +795,8 @@ def gas_test_parameter_args(
 
     if include_many:
         # Fit as many authorizations as possible within the transaction gas
-        # limit.
+        # limit. 21,000 is a conservative overestimate of the base intrinsic
+        # cost (fork is unavailable at parametrization time).
         max_gas = 16_777_216 - 21_000
         if execution_gas_allowance:
             # Leave some gas for the execution of the test code.

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3848,7 +3848,8 @@ def test_many_delegations(
         max_gas = tx_gas_limit_cap
     else:
         max_gas = env.gas_limit
-    gas_for_delegations = max_gas - 21_000 - 20_000 - (3 * 2)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    gas_for_delegations = max_gas - intrinsic_gas - 20_000 - (3 * 2)
 
     delegation_count = gas_for_delegations // Spec.GAS_AUTH_PER_EMPTY_ACCOUNT
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3895,6 +3895,7 @@ def test_many_delegations(
 @pytest.mark.exception_test
 def test_invalid_transaction_after_authorization(
     blockchain_test: BlockchainTestFiller,
+    fork: Fork,
     pre: Alloc,
 ) -> None:
     """
@@ -3903,6 +3904,10 @@ def test_invalid_transaction_after_authorization(
     """
     auth_signer = pre.fund_eoa()
     recipient = pre.fund_eoa(amount=0)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
 
     txs = [
         Transaction(
@@ -3921,7 +3926,7 @@ def test_invalid_transaction_after_authorization(
         Transaction(
             sender=auth_signer,
             nonce=0,
-            gas_limit=21_000,
+            gas_limit=intrinsic_gas,
             to=recipient,
             value=1,
             error=TransactionException.NONCE_MISMATCH_TOO_LOW,


### PR DESCRIPTION
## Summary

- Pass `_fork` to `transactions()` in EIP-7002, EIP-7251, and EIP-7685 system contract tests that were falling back to hardcoded gas limits.
- Replace hardcoded `gas_limit=21_000` with the fork's intrinsic gas calculator in the EIP-7702 nonce mismatch test (empty account + value costs 30,000 under EIP-2780).
- Replace stale `21_000` with the intrinsic gas calculator in `test_many_delegations` where `fork` is available; document the overestimate in `test_gas.py` where it isn't.
- Add `sends_value=True` to EIP-7002/7251 contract deployment intrinsic gas calculations (transactions send the system contract fee as value).
- Generalize "21,000 gas" comments to "base intrinsic gas (fork-dependent)" in EIP-7623 docstrings.

## Test plan

- [x] `uvx tox -e static` passes after each commit.
- [x] `uv run fill` passes on all modified test modules.