### PR TITLE
fix(tests): replace hardcoded gas constants in Cancun blob tests

### DIFF
--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -9,6 +9,7 @@ from execution_testing import (
     Environment,
     Fork,
     Hash,
+    RecipientType,
     Transaction,
     add_kzg_version,
 )
@@ -333,13 +334,18 @@ def non_zero_blob_gas_used_genesis_block(
         for i in range(0, parent_blobs, max_blobs_per_tx)
     ]
 
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+
     def create_blob_transaction(blob_range: Iterable[int]) -> Transaction:
         return Transaction(
             ty=Spec.BLOB_TX_TYPE,
             sender=sender,
             to=empty_account_destination,
             value=1,
-            gas_limit=45_000,
+            gas_limit=intrinsic_gas,
             max_fee_per_gas=tx_max_fee_per_gas,
             max_priority_fee_per_gas=0,
             max_fee_per_blob_gas=blob_gas_price_calculator(

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -15,6 +15,7 @@ from execution_testing import (
     Hash,
     Header,
     NetworkWrappedTransaction,
+    RecipientType,
     Transaction,
     TransactionException,
 )
@@ -42,9 +43,12 @@ def tx_value() -> int:
 
 
 @pytest.fixture
-def tx_gas() -> int:
+def tx_gas(fork: Fork) -> int:
     """Gas allocated to transactions sent during test."""
-    return 21_000
+    return fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Hash,
     Header,
     Op,
+    RecipientType,
     Transaction,
     add_kzg_version,
 )
@@ -114,10 +115,13 @@ def pre_fork_blocks(
         blob_index = 0
         remaining_blobs = pre_fork_blobs_per_block
         max_blobs_per_tx = fork.max_blobs_per_tx(timestamp=0)
+        blob_tx_gas_limit = fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+            sends_value=True,
+        )
 
         while remaining_blobs > 0:
             tx_blobs = min(remaining_blobs, max_blobs_per_tx)
-            blob_tx_gas_limit = 21_000
             txs.append(
                 Transaction(
                     ty=Spec.BLOB_TX_TYPE,
@@ -266,6 +270,10 @@ def post_fork_blocks(
         blob_index = 0
         remaining_blobs = post_fork_blobs_per_block
         max_blobs_per_tx = fork.max_blobs_per_tx(timestamp=FORK_TIMESTAMP)
+        blob_tx_gas_limit = fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+            sends_value=True,
+        )
         while remaining_blobs > 0:
             tx_blobs = min(remaining_blobs, max_blobs_per_tx)
             txs.append(
@@ -273,7 +281,7 @@ def post_fork_blocks(
                     ty=Spec.BLOB_TX_TYPE,
                     to=destination_account,
                     value=1,
-                    gas_limit=100_000,
+                    gas_limit=blob_tx_gas_limit,
                     max_fee_per_gas=1_000_000,
                     max_priority_fee_per_gas=10,
                     max_fee_per_blob_gas=100,


### PR DESCRIPTION
## Summary

- Replace hardcoded `gas_limit=21_000` and `gas_limit=100_000` in `test_excess_blob_gas_fork_transition.py` with `fork.transaction_intrinsic_cost_calculator()` using `RecipientType.EMPTY_ACCOUNT` and `sends_value=True`.
- Replace hardcoded `tx_gas` fixture returning `21_000` in `test_blob_txs_full.py` with the same fork-aware calculator.
- Replace hardcoded `gas_limit=45_000` in the blob conftest helper with the calculator.

Under EIP-2780, sending value to an empty/new account costs 30,000 gas (up from 21,000). These Cancun tests are `valid_from("Cancun")`, so they also run for Amsterdam and later forks. Without this fix, the first two findings produce intrinsically invalid transactions under EIP-2780.

## Test plan

- [x] `uvx tox -e static` passes.
- [x] `uv run fill -n 8 tests/cancun/` — 21,600 tests passed.