### PR TITLE
fix(spec-tools): load txs that carry no signature material

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/cli.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/cli.py
@@ -137,7 +137,7 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
        store a tx whose signature is deliberately invalid without
        ``v``/``r``/``s`` or ``secretKey`` (the fixture format cannot
        express explicit signature values), expecting the fork to
-       reject it. Default the components to zero,; leaving them unset
+       reject it. Default the components to zero; leaving them unset
        would make ``Transaction.rlp`` try to auto-sign a key-less tx
        and die on an assertion.
     """

--- a/src/ethereum_spec_tools/evm_tools/t8n/cli.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/cli.py
@@ -137,10 +137,10 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
        store a tx whose signature is deliberately invalid without
        ``v``/``r``/``s`` or ``secretKey`` (the fixture format cannot
        express explicit signature values), expecting the fork to
-       reject it. Default the components to zero, like the previous
-       parser did; leaving them unset would make ``Transaction.rlp``
-       try to auto-sign a key-less tx and die on an assertion.
-    """
+       reject it. Default the components to zero,; leaving them unset
+       would make ``Transaction.rlp`` try to auto-sign a key-less tx
+       and die on an assertion.
+   """
     auth_list = tx.get("authorizationList")
     if isinstance(auth_list, list):
         tx["authorizationList"] = [

--- a/src/ethereum_spec_tools/evm_tools/t8n/cli.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/cli.py
@@ -119,7 +119,7 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
     """
     Drop fields that the testing ``Transaction`` model rejects.
 
-    Two boundary mismatches to smooth over:
+    Three boundary mismatches to smooth over:
 
     1. ``yParity`` on authorization tuples. The testing
        ``AuthorizationTuple`` serializer emits both ``v`` and
@@ -133,6 +133,13 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
        the model rejects the pair with
        ``InvalidSignaturePrivateKeyError``. Strip ``secretKey``
        whenever ``v`` is set (i.e. the tx is already signed).
+    3. A tx with no signature material at all. Filled state tests
+       store a tx whose signature is deliberately invalid without
+       ``v``/``r``/``s`` or ``secretKey`` (the fixture format cannot
+       express explicit signature values), expecting the fork to
+       reject it. Default the components to zero, like the previous
+       parser did; leaving them unset would make ``Transaction.rlp``
+       try to auto-sign a key-less tx and die on an assertion.
     """
     auth_list = tx.get("authorizationList")
     if isinstance(auth_list, list):
@@ -144,6 +151,13 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
         ]
     if "secretKey" in tx and tx.get("v") is not None:
         tx = {k: v for k, v in tx.items() if k != "secretKey"}
+    if not any(
+        tx.get(key) is not None
+        for key in ("secretKey", "v", "yParity", "r", "s")
+    ):
+        tx["v"] = "0x00"
+        tx["r"] = "0x00"
+        tx["s"] = "0x00"
     return tx
 
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/cli.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/cli.py
@@ -140,7 +140,7 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
        reject it. Default the components to zero,; leaving them unset
        would make ``Transaction.rlp`` try to auto-sign a key-less tx
        and die on an assertion.
-   """
+    """
     auth_list = tx.get("authorizationList")
     if isinstance(auth_list, list):
         tx["authorizationList"] = [


### PR DESCRIPTION
Fixes the `json-loader` CI failure on this branch: 136 cases, all `test_bad_v_r_s`, all failing with `AssertionError: secret_key or signer must be set` ([run 28782882693](https://github.com/ethereum/execution-specs/actions/runs/28782882693/job/85342678116)) from https://github.com/ethereum/execution-specs/pull/2924.

## Bug

Filled state tests store a tx whose signature is deliberately invalid with no signature material at all: the state-test fixture format cannot express explicit `v`/`r`/`s` (the blockchain format carries them inside `txbytes`), so these fixtures rely on `expectException`. The json_loader feeds that tx to the CLI t8n verbatim. The new CLI parser builds a testing `Transaction` and RLP-encodes it for the returned body; RLP serialization auto-signs a tx whose `v`/`r`/`s` were never set and hits `assert signing_key is not None` because there is no `secretKey` and the sender EOA carries no key. The previous parser (`t8n_types.Txs.parse_json_tx`) defaulted each missing component to `0x00` and let the fork reject the invalid signature.

## Fix

`_normalize_tx_json` now defaults `v`/`r`/`s` to zero when a tx carries none of `v`/`r`/`s`/`secretKey`, restoring the previous parser's behavior: the tx executes with an invalid signature and is rejected, which is exactly what these fixtures assert.

## Verification

- The filled `bad_v_r_s.json` fixture is byte-identical between this branch and `forks/amsterdam` (only the provenance URL differs), so the failure is purely in the loader path and this fix cannot change any fixture output.
- Filled `tests/frontier/validation/test_transaction.py::test_bad_v_r_s` locally into `tests/json_loader/fixtures` for Homestead and Prague and ran `pytest tests/json_loader`: all cases pass with this fix and reproduce the CI assertion without it.
- The new branch only triggers for a tx with no signature material at all; signed txs and `secretKey`-carrying txs take exactly the same path as before, so behavior for every other input is unchanged.
