### PR TITLE
refactor(specs,tests): Remove intrinsic state gas concept

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -250,13 +250,10 @@ def _compute_deploy_gas_limit(
     sstore_state_gas = sstore.state_cost(fork)
     sstore_regular_gas = sstore.gas_cost(fork) - sstore_state_gas
 
-    # Back out the state gas folded into TX_CREATE.
-    intrinsic_state_gas = fork.transaction_intrinsic_state_gas(
-        contract_creation=True
-    )
-    intrinsic_regular_gas = (
-        intrinsic_gas_calculator(calldata=initcode, contract_creation=True)
-        - intrinsic_state_gas
+    # The intrinsic cost is now regular-only: the created account's
+    # NEW_ACCOUNT state gas is charged at the top frame, not folded in.
+    intrinsic_regular_gas = intrinsic_gas_calculator(
+        calldata=initcode, contract_creation=True
     )
 
     # Regular portion, bound by the gas cap.
@@ -274,8 +271,7 @@ def _compute_deploy_gas_limit(
     regular_gas *= 2
 
     # State portion, from the block reservoir.
-    state_gas = intrinsic_state_gas
-    state_gas += fork.code_deposit_state_gas(code_size=deploy_code_size)
+    state_gas = fork.code_deposit_state_gas(code_size=deploy_code_size)
     state_gas += storage_slots * sstore_state_gas
 
     deploy_gas_limit = regular_gas + state_gas

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -768,17 +768,6 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         pass
 
     @classmethod
-    def transaction_intrinsic_state_gas(
-        cls,
-        *,
-        contract_creation: bool = False,
-        authorization_count: int = 0,
-    ) -> int:
-        """Return intrinsic state gas (zero pre-Amsterdam)."""
-        del contract_creation, authorization_count
-        return 0
-
-    @classmethod
     def transaction_top_frame_gas_calculator(
         cls,
     ) -> TopFrameGasCalculator:

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
@@ -128,28 +128,6 @@ class EIP2780(BaseFork):
         return fn
 
     @classmethod
-    def transaction_intrinsic_state_gas(
-        cls,
-        *,
-        contract_creation: bool = False,
-        authorization_count: int = 0,
-    ) -> int:
-        """
-        Return the intrinsic state gas for a transaction.
-
-        Under EIP-2780 neither authorizations nor contract creation
-        contribute intrinsic state gas: the authority account-creation
-        and delegation-write costs and the created account's
-        ``NEW_ACCOUNT`` are all state-dependent and charged at the top
-        frame instead.
-        """
-        del contract_creation, authorization_count
-        return super(EIP2780, cls).transaction_intrinsic_state_gas(
-            contract_creation=False,
-            authorization_count=0,
-        )
-
-    @classmethod
     def transaction_top_frame_gas_calculator(
         cls,
     ) -> TopFrameGasCalculator:

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -233,30 +233,6 @@ class EIP8037(BaseFork):
         return fn
 
     @classmethod
-    def transaction_intrinsic_state_gas(
-        cls,
-        *,
-        contract_creation: bool = False,
-        authorization_count: int = 0,
-    ) -> int:
-        """
-        Return the intrinsic state gas for a transaction. Creation
-        adds `STATE_BYTES_PER_NEW_ACCOUNT * cpsb`, and each
-        authorization adds
-        `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) * cpsb`.
-        """
-        cpsb = cls.cost_per_state_byte()
-        state_gas = 0
-        if contract_creation:
-            state_gas += STATE_BYTES_PER_NEW_ACCOUNT * cpsb
-        state_gas += (
-            (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
-            * cpsb
-            * authorization_count
-        )
-        return state_gas
-
-    @classmethod
     def _calculate_sstore_state_gas(
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -806,8 +806,6 @@ def process_unchecked_system_transaction(
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
-        intrinsic_regular_gas=Uint(0),
-        intrinsic_state_gas=Uint(0),
     )
 
     system_tx_message = Message(
@@ -1034,7 +1032,7 @@ def process_transaction(
     sender = recover_sender(tx)
     intrinsic = validate_transaction(tx, sender)
 
-    intrinsic_gas = Uint(intrinsic.regular) + Uint(intrinsic.state)
+    intrinsic_gas = Uint(intrinsic.regular)
 
     (
         effective_gas_price,
@@ -1098,15 +1096,9 @@ def process_transaction(
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        intrinsic_regular_gas=intrinsic.regular,
-        intrinsic_state_gas=intrinsic.state,
     )
 
-    message = prepare_message(
-        block_env,
-        tx_env,
-        tx,
-    )
+    message = prepare_message(block_env, tx_env, tx)
 
     tx_output = process_message_call(message)
 
@@ -1135,7 +1127,7 @@ def process_transaction(
     # transfer miner fees
     create_ether(tx_state, block_env.coinbase, U256(transaction_fee))
 
-    tx_state_gas = int(tx_env.intrinsic_state_gas) + tx_output.state_gas_used
+    tx_state_gas = tx_output.state_gas_used
     tx_regular_gas = tx_gas_used_before_refund - Uint(max(0, tx_state_gas))
     block_output.block_gas_used += tx_regular_gas
     block_output.block_state_gas_used += Uint(max(0, tx_state_gas))

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -25,12 +25,7 @@ from .exceptions import (
     InitCodeTooLargeError,
     TransactionTypeError,
 )
-from .fork_types import (
-    Authorization,
-    RegularGas,
-    StateGas,
-    VersionedHash,
-)
+from .fork_types import Authorization, RegularGas, VersionedHash
 
 
 @final
@@ -40,14 +35,6 @@ class IntrinsicGasCost:
 
     regular: RegularGas
     """Regular execution gas (calldata, base cost, access list, etc.)."""
-
-    state: StateGas
-    """
-    State growth gas (account creation, storage set, authorization) per
-    [EIP-8037].
-
-    [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
-    """
 
     calldata_floor: RegularGas
     """
@@ -610,7 +597,7 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx, sender)
-    intrinsic_gas = Uint(intrinsic.regular) + Uint(intrinsic.state)
+    intrinsic_gas = Uint(intrinsic.regular)
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
     if intrinsic.calldata_floor > tx.gas:
@@ -665,13 +652,10 @@ def calculate_intrinsic_cost(
     charges.
 
     This function takes a transaction and gas_limit as parameters and
-    returns the intrinsic regular gas cost, intrinsic state gas cost, and the
-    minimum gas cost used by the transaction based on the calldata size.
+    returns the intrinsic regular gas cost and the minimum gas cost used by
+    the transaction based on the calldata size.
     """
-    from .vm.gas import (
-        GasCosts,
-        init_code_cost,
-    )
+    from .vm.gas import GasCosts, init_code_cost
 
     tokens_in_calldata = count_tokens_in_data(tx.data)
 
@@ -680,18 +664,15 @@ def calculate_intrinsic_cost(
     is_create = tx.to == Bytes0(b"")
     is_self_transfer = tx.to == sender
 
-    recipient_regular_gas = Uint(0)
-    recipient_state_gas = Uint(0)
+    recipient_gas = Uint(0)
     if is_create:
-        recipient_regular_gas = GasCosts.CREATE_ACCESS + init_code_cost(
-            ulen(tx.data)
-        )
+        recipient_gas = GasCosts.CREATE_ACCESS + init_code_cost(ulen(tx.data))
         if tx.value > U256(0):
-            recipient_regular_gas += GasCosts.TRANSFER_LOG_COST
+            recipient_gas += GasCosts.TRANSFER_LOG_COST
     elif not is_self_transfer:
-        recipient_regular_gas = GasCosts.COLD_ACCOUNT_ACCESS
+        recipient_gas = GasCosts.COLD_ACCOUNT_ACCESS
         if tx.value > U256(0):
-            recipient_regular_gas += (
+            recipient_gas += (
                 GasCosts.TRANSFER_LOG_COST + GasCosts.TX_VALUE_COST
             )
 
@@ -711,10 +692,9 @@ def calculate_intrinsic_cost(
     # Data token floor cost for access list bytes.
     access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR
 
-    auth_regular_gas = Uint(0)
-    auth_state_gas = Uint(0)
+    auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
-        auth_regular_gas = GasCosts.REGULAR_PER_AUTH_BASE_COST * ulen(
+        auth_cost = GasCosts.REGULAR_PER_AUTH_BASE_COST * ulen(
             tx.authorizations
         )
 
@@ -729,19 +709,14 @@ def calculate_intrinsic_cost(
         total_floor_tokens * GasCosts.TX_DATA_TOKEN_FLOOR + GasCosts.TX_BASE
     )
 
-    intrinsic_regular_gas = (
-        GasCosts.TX_BASE
-        + data_cost
-        + recipient_regular_gas
-        + access_list_cost
-        + auth_regular_gas
-    )
-
-    intrinsic_state_gas = recipient_state_gas + auth_state_gas
-
     return IntrinsicGasCost(
-        regular=RegularGas(intrinsic_regular_gas),
-        state=StateGas(intrinsic_state_gas),
+        regular=RegularGas(
+            GasCosts.TX_BASE
+            + data_cost
+            + recipient_gas
+            + access_list_cost
+            + auth_cost
+        ),
         calldata_floor=RegularGas(data_floor_gas_cost),
     )
 

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -132,8 +132,6 @@ class TransactionEnvironment:
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    intrinsic_regular_gas: Uint
-    intrinsic_state_gas: Uint
 
 
 @final

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -629,9 +629,6 @@ def test_create_tx_below_total_intrinsic(
         contract_creation=True,
         calldata=bytes(initcode),
     )
-    assert fork.transaction_intrinsic_state_gas(contract_creation=True) == 0, (
-        "creation intrinsic is regular-only under EIP-2780"
-    )
 
     tx = Transaction(
         to=None,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -41,9 +41,6 @@ def test_sstore_via_delegation_pointer(
     contract code in the EOA's context. The SSTORE state gas should
     be charged from the reservoir just as it would for a direct call.
     """
-    auth_state_gas = fork.transaction_intrinsic_state_gas(
-        authorization_count=1,
-    )
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
     storage = Storage()
@@ -54,17 +51,22 @@ def test_sstore_via_delegation_pointer(
     # EOA with pre-existing delegation to the contract
     delegator = pre.fund_eoa(delegation=contract)
 
+    authorization = AuthorizationTuple(
+        address=contract,
+        nonce=0,
+        signer=delegator,
+        creates_account=False,
+        writes_delegation=True,
+        first_write=True,
+    )
+    auth_state_gas = fork.transaction_top_frame_state_gas(
+        authorizations=[authorization]
+    )
     sender = pre.fund_eoa()
     tx = Transaction(
         to=delegator,
         state_gas_reservoir=auth_state_gas + sstore_state_gas,
-        authorization_list=[
-            AuthorizationTuple(
-                address=contract,
-                nonce=0,
-                signer=delegator,
-            ),
-        ],
+        authorization_list=[authorization],
         sender=sender,
     )
 
@@ -117,12 +119,9 @@ def test_delegation_pointer_new_account_state_gas(
     is charged identically to a direct call.
     """
     gas_costs = fork.gas_costs()
-    auth_state_gas = fork.transaction_intrinsic_state_gas(
-        authorization_count=1,
-    )
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    target = 0xDEAD
+    target = pre.nonexistent_account()
 
     parent_storage = Storage()
     contract = pre.deploy_contract(
@@ -137,6 +136,18 @@ def test_delegation_pointer_new_account_state_gas(
 
     # EOA delegates to the contract
     delegator = pre.fund_eoa(delegation=contract, amount=1)
+
+    authorization = AuthorizationTuple(
+        address=contract,
+        nonce=0,
+        signer=delegator,
+        creates_account=False,
+        writes_delegation=True,
+        first_write=True,
+    )
+    auth_state_gas = fork.transaction_top_frame_state_gas(
+        authorizations=[authorization]
+    )
 
     sender = pre.fund_eoa()
     tx = Transaction(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -51,13 +51,16 @@ def test_sstore_via_delegation_pointer(
     # EOA with pre-existing delegation to the contract
     delegator = pre.fund_eoa(delegation=contract)
 
+    # The authorization re-targets an already-delegated authority whose
+    # nonce (1, from the delegation setup) no longer matches nonce=0, so
+    # it is invalid and charges no top-frame state gas.
     authorization = AuthorizationTuple(
         address=contract,
         nonce=0,
         signer=delegator,
         creates_account=False,
-        writes_delegation=True,
-        first_write=True,
+        writes_delegation=False,
+        first_write=False,
     )
     auth_state_gas = fork.transaction_top_frame_state_gas(
         authorizations=[authorization]
@@ -137,13 +140,16 @@ def test_delegation_pointer_new_account_state_gas(
     # EOA delegates to the contract
     delegator = pre.fund_eoa(delegation=contract, amount=1)
 
+    # The authorization re-targets an already-delegated authority whose
+    # nonce (1, from the delegation setup) no longer matches nonce=0, so
+    # it is invalid and charges no top-frame state gas.
     authorization = AuthorizationTuple(
         address=contract,
         nonce=0,
         signer=delegator,
         creates_account=False,
-        writes_delegation=True,
-        first_write=True,
+        writes_delegation=False,
+        first_write=False,
     )
     auth_state_gas = fork.transaction_top_frame_state_gas(
         authorizations=[authorization]
@@ -153,13 +159,7 @@ def test_delegation_pointer_new_account_state_gas(
     tx = Transaction(
         to=delegator,
         state_gas_reservoir=auth_state_gas + new_account_state_gas,
-        authorization_list=[
-            AuthorizationTuple(
-                address=contract,
-                nonce=0,
-                signer=delegator,
-            ),
-        ],
+        authorization_list=[authorization],
         sender=sender,
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -330,11 +330,10 @@ def test_intrinsic_regular_gas_exceeds_cap(
         return_cost_deducted_prior_execution=True,
     )
     floor = floor_cost(data=b"", access_list=access_list)
-    state = fork.transaction_intrinsic_state_gas()
-    tx_gas = regular + state + 1_000_000
+    tx_gas = regular + 1_000_000
 
     assert max(regular, floor) > cap, "cap check must fire"
-    assert regular + state <= tx_gas, "sufficiency check must not fire"
+    assert regular <= tx_gas, "sufficiency check must not fire"
     assert floor <= tx_gas
 
     tx = Transaction(
@@ -380,12 +379,11 @@ def test_intrinsic_regular_gas_exceeds_cap_with_floor_below_cap(
         return_cost_deducted_prior_execution=True,
     )
     floor = floor_cost(data=b"", access_list=access_list)
-    state = fork.transaction_intrinsic_state_gas()
-    tx_gas = regular + state + 1_000_000
+    tx_gas = regular + 1_000_000
 
     assert regular > cap, "regular operand must exceed the cap"
     assert floor < cap, "calldata floor must stay below the cap"
-    assert regular + state <= tx_gas, "sufficiency check must not fire"
+    assert regular <= tx_gas, "sufficiency check must not fire"
 
     tx = Transaction(
         ty=1,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -360,9 +360,6 @@ def test_creation_tx_regular_check_uses_full_tx_gas(
     intrinsic_regular = fork.transaction_intrinsic_cost_calculator()(
         contract_creation=True
     )
-    assert fork.transaction_intrinsic_state_gas(contract_creation=True) == 0, (
-        "creation intrinsic is regular-only under EIP-2780"
-    )
 
     # Tight boundary: after the filler consumes gas_limit_cap, exactly
     # `intrinsic_regular + 1` regular gas remains in the block.
@@ -862,7 +859,7 @@ def test_creation_tx_failure_preserves_intrinsic_state_gas(
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
 
-    create_intrinsic_state = fork.transaction_intrinsic_state_gas(
+    create_intrinsic_state = fork.transaction_top_frame_state_gas(
         contract_creation=True,
     )
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
@@ -73,17 +73,14 @@ def _regular_intrinsic(
     calldata: bytes = b"",
 ) -> int:
     """
-    Return the regular (non-state) intrinsic gas of a set-code
+    Return the intrinsic gas of a set-code
     transaction: the full intrinsic less the authorization state gas.
     """
-    total = fork.transaction_intrinsic_cost_calculator()(
+    return fork.transaction_intrinsic_cost_calculator()(
         authorization_list_or_count=n,
         access_list=access_list,
         calldata=calldata,
         return_cost_deducted_prior_execution=True,
-    )
-    return total - fork.transaction_intrinsic_state_gas(
-        authorization_count=n,
     )
 
 
@@ -118,9 +115,7 @@ def test_auth_regular_intrinsic_magnitude(
     The regular intrinsic above the ``n=0`` base must equal
     ``n * regular_per_auth`` plus the access-list delta (derived from
     the calculator itself so the calldata-floor contribution of the
-    access-list bytes is accounted for). The state portion is excluded
-    via ``transaction_intrinsic_state_gas`` and is left to the EIP-8037
-    suite.
+    access-list bytes is accounted for).
     """
     contract = pre.deploy_contract(code=Op.STOP)
 

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -677,11 +677,6 @@ def test_tx_gas_limit_cap_authorized_tx(
             access_list=make_access_list(auth_count),
             authorization_list_or_count=auth_count,
         )
-        if fork.is_eip_enabled(8037):
-            # EIP-8037 caps only the regular dimension, not state gas.
-            cost -= fork.transaction_intrinsic_state_gas(
-                authorization_count=auth_count
-            )
         return cost
 
     auth_list_length = max_count_with_intrinsic_cost_at_most(


### PR DESCRIPTION
Remove the "intrinsic state gas" concept from the Amsterdam fork. Under EIP-8037's two-dimensional gas model, the intrinsic cost was previously split into a `regular` and a `state` component, with the state portion accounting for account creation, storage set, and authorization state growth up front. In practice none of these costs are truly intrinsic: they all depend on the actual state touched during execution, so following EIP-2780 they are charged at the top frame instead. This series drops the now-redundant intrinsic state gas plumbing so the intrinsic cost is a single `regular` value again.

The change spans three layers:

- **Specs (`src/ethereum/forks/amsterdam/`)** — `refactor(specs): Remove intrinsic state gas concept`
  - Drop the `state` field from `IntrinsicGasCost` and fold the recipient and authorization costs into a single `regular` intrinsic value in `calculate_intrinsic_cost`.
  - Remove `intrinsic_regular_gas` / `intrinsic_state_gas` from `TransactionEnvironment`, and stop seeding intrinsic state gas in `process_transaction` and `process_unchecked_system_transaction`. The transaction's state gas now comes solely from `tx_output.state_gas_used`.

- **Test forks (`packages/testing/`)** — `refactor(test-forks): Remove intrinsic state gas`
  - Delete the `transaction_intrinsic_state_gas` classmethod from `BaseFork` and its `EIP2780` / `EIP8037` overrides, which are no longer referenced now that these costs are computed at the top frame.

- **Tests (`tests/amsterdam/`)** — `fix(tests): Fix intrinsic state gas usages`
  - Update state-gas tests (create, delegation pointer, pricing, reservoir, set-code auth gas, tx gas limit) to reflect that account-creation and authorization state growth is accounted at the top frame rather than as intrinsic gas.