### PR TITLE
 refactor(test-clis): Refactor LazyAlloc

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -438,6 +438,18 @@ class LazyAlloc(Generic[TRaw]):
         """Return state root of the allocation."""
         return self._state_root
 
+    def serialize_to_file(
+        self, file_path: Path, **model_dump_config: Any
+    ) -> None:
+        """
+        Serialize the allocation to ``file_path`` as JSON.
+
+        The default materializes the ``Alloc`` and dumps it. Subclasses
+        backed by already-serialized data override this to write their
+        cache directly and skip the round trip through ``Alloc``.
+        """
+        file_path.write_text(self.get().model_dump_json(**model_dump_config))
+
 
 JSONDict = Dict[str, Any]
 
@@ -453,6 +465,23 @@ class LazyAllocJson(LazyAlloc[JSONDict]):
         """Validate the alloc."""
         return Alloc.model_validate(self.raw)
 
+    def serialize_to_file(
+        self, file_path: Path, **model_dump_config: Any
+    ) -> None:
+        """
+        Dump the cached JSON dict without round-tripping through ``Alloc``.
+
+        Only ``indent`` applies; the dict is already-serialized data, so
+        pydantic options such as ``by_alias`` / ``exclude_none`` are moot.
+        """
+        with open(file_path, "w") as f:
+            json.dump(
+                self.raw,
+                f,
+                ensure_ascii=True,
+                indent=model_dump_config.get("indent"),
+            )
+
 
 class LazyAllocStr(LazyAlloc[str]):
     """
@@ -464,6 +493,13 @@ class LazyAllocStr(LazyAlloc[str]):
     def validate(self) -> Alloc:
         """Validate the alloc."""
         return Alloc.model_validate_json(self.raw)
+
+    def serialize_to_file(
+        self, file_path: Path, **model_dump_config: Any
+    ) -> None:
+        """Write the cached JSON string verbatim (no re-serialization)."""
+        del model_dump_config  # raw already encodes its own formatting
+        file_path.write_text(self.raw)
 
 
 @dataclass(kw_only=True)
@@ -513,6 +549,22 @@ class LazyAllocFile(LazyAlloc[Path]):
                         account_data
                     )
         return Alloc.model_validate(accumulated)
+
+    def serialize_to_file(
+        self, file_path: Path, **model_dump_config: Any
+    ) -> None:
+        """
+        Copy the backing file byte-for-byte, avoiding a parse/dump cycle.
+
+        If the backing temp dir was already cleaned up (e.g. a
+        chained-block t8n consumed it on the next block), fall back to
+        dumping the cached ``Alloc`` so debug output still captures the
+        input.
+        """
+        if Path(self.raw).exists():
+            shutil.copyfile(self.raw, file_path)
+        else:
+            super().serialize_to_file(file_path, **model_dump_config)
 
 
 @dataclass(kw_only=True)

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -428,8 +428,8 @@ class LazyAlloc(Generic[TRaw]):
         """Validate the alloc."""
         raise NotImplementedError("validate method not implemented.")
 
-    def get(self) -> Alloc:
-        """Model validate the allocation and return it."""
+    def materialize(self) -> Alloc:
+        """Materialize the allocation, validating it on first access."""
         if self.alloc is None:
             self.alloc = self.validate()
         return self.alloc
@@ -438,17 +438,27 @@ class LazyAlloc(Generic[TRaw]):
         """Return state root of the allocation."""
         return self._state_root
 
+    def serialize(self, **model_dump_config: Any) -> str:
+        """
+        Serialize the allocation to a JSON string.
+
+        The default materializes the ``Alloc`` and dumps it. Subclasses
+        backed by already-serialized data override this to return their
+        cache directly and skip the round trip through ``Alloc``.
+        """
+        return self.materialize().model_dump_json(**model_dump_config)
+
     def serialize_to_file(
         self, file_path: Path, **model_dump_config: Any
     ) -> None:
         """
         Serialize the allocation to ``file_path`` as JSON.
 
-        The default materializes the ``Alloc`` and dumps it. Subclasses
-        backed by already-serialized data override this to write their
-        cache directly and skip the round trip through ``Alloc``.
+        Writes whatever :meth:`serialize` produces. ``LazyAllocFile``
+        overrides this with a byte-for-byte copy that avoids building
+        the JSON string at all.
         """
-        file_path.write_text(self.get().model_dump_json(**model_dump_config))
+        file_path.write_text(self.serialize(**model_dump_config))
 
 
 JSONDict = Dict[str, Any]
@@ -465,22 +475,18 @@ class LazyAllocJson(LazyAlloc[JSONDict]):
         """Validate the alloc."""
         return Alloc.model_validate(self.raw)
 
-    def serialize_to_file(
-        self, file_path: Path, **model_dump_config: Any
-    ) -> None:
+    def serialize(self, **model_dump_config: Any) -> str:
         """
         Dump the cached JSON dict without round-tripping through ``Alloc``.
 
         Only ``indent`` applies; the dict is already-serialized data, so
         pydantic options such as ``by_alias`` / ``exclude_none`` are moot.
         """
-        with open(file_path, "w") as f:
-            json.dump(
-                self.raw,
-                f,
-                ensure_ascii=True,
-                indent=model_dump_config.get("indent"),
-            )
+        return json.dumps(
+            self.raw,
+            ensure_ascii=True,
+            indent=model_dump_config.get("indent"),
+        )
 
 
 class LazyAllocStr(LazyAlloc[str]):
@@ -494,12 +500,10 @@ class LazyAllocStr(LazyAlloc[str]):
         """Validate the alloc."""
         return Alloc.model_validate_json(self.raw)
 
-    def serialize_to_file(
-        self, file_path: Path, **model_dump_config: Any
-    ) -> None:
-        """Write the cached JSON string verbatim (no re-serialization)."""
+    def serialize(self, **model_dump_config: Any) -> str:
+        """Return the cached JSON string verbatim (no re-serialization)."""
         del model_dump_config  # raw already encodes its own formatting
-        file_path.write_text(self.raw)
+        return self.raw
 
 
 @dataclass(kw_only=True)
@@ -520,7 +524,7 @@ class LazyAllocFile(LazyAlloc[Path]):
     LazyAllocFile is dropped. That lets a chained next-block t8n call
     consume the alloc directly from disk (via ``--input.alloc=<path>`` for
     geth, or ``shutil.copyfile`` for filesystem t8ns) without round-tripping
-    through ``Alloc.get().model_dump_json()`` in Python.
+    through ``LazyAlloc.materialize().model_dump_json()`` in Python.
     """
 
     _keepalive: Optional[tempfile.TemporaryDirectory] = field(default=None)
@@ -610,16 +614,15 @@ class TransitionToolInput:
         For ``LazyAllocFile`` inputs whose backing file is still on disk
         (chained-block handoff: previous t8n call's temp dir is pinned via
         the keepalive field), the alloc is copied byte-for-byte rather than
-        round-tripped through ``Alloc.get().model_dump_json()``.
+        round-tripped through ``LazyAlloc.materialize().model_dump_json()``.
         """
         alloc_path = directory_path / "alloc.json"
-        if (
-            isinstance(self.alloc, LazyAllocFile)
-            and Path(self.alloc.raw).exists()
-        ):
-            shutil.copyfile(self.alloc.raw, alloc_path)
+        if isinstance(self.alloc, LazyAlloc):
+            self.alloc.serialize_to_file(alloc_path, **model_dump_config)
         else:
-            alloc_path.write_text(self._serialize_alloc(**model_dump_config))
+            alloc_path.write_text(
+                self.alloc.model_dump_json(**model_dump_config)
+            )
 
         env_contents = self.env.model_dump_json(**model_dump_config)
         txs_contents = (
@@ -646,13 +649,9 @@ class TransitionToolInput:
 
     def _serialize_alloc(self, **model_dump_config: Any) -> str:
         """Serialize ``self.alloc`` to a JSON string."""
-        if isinstance(self.alloc, Alloc):
-            return self.alloc.model_dump_json(**model_dump_config)
-        if isinstance(self.alloc, LazyAllocStr):
-            return self.alloc.raw
-        if isinstance(self.alloc, LazyAllocFile):
-            return self.alloc.get().model_dump_json(**model_dump_config)
-        raise Exception(f"Invalid alloc type: {type(self.alloc)}")
+        if isinstance(self.alloc, LazyAlloc):
+            return self.alloc.serialize(**model_dump_config)
+        return self.alloc.model_dump_json(**model_dump_config)
 
     def model_dump_json(
         self, *, exclude_alloc: bool = False, **model_dump_config: Any
@@ -699,7 +698,7 @@ class TransitionToolInput:
         elif isinstance(self.alloc, LazyAllocJson):
             alloc_contents = self.alloc.raw
         elif isinstance(self.alloc, LazyAllocFile):
-            alloc_contents = self.alloc.get().model_dump(
+            alloc_contents = self.alloc.materialize().model_dump(
                 mode=mode, **model_dump_config
             )
         else:
@@ -757,7 +756,7 @@ class TransitionToolOutput:
         different JSON file.
 
         `alloc.json` is referenced by path and parsed incrementally on
-        `.get()` via `LazyAllocFile`, so the full file is never held in
+        `.materialize()` via `LazyAllocFile`, so the full file is never held in
         memory alongside the validated `Alloc`.
         """
         result_data = (directory_path / "result.json").read_text()

--- a/packages/testing/src/execution_testing/client_clis/file_utils.py
+++ b/packages/testing/src/execution_testing/client_clis/file_utils.py
@@ -1,7 +1,6 @@
 """Methods to work with the filesystem and json."""
 
 import os
-import shutil
 import stat
 from json import dump
 from pathlib import Path
@@ -10,9 +9,7 @@ from typing import Any, Dict
 from pydantic import BaseModel, RootModel
 
 from execution_testing.client_clis.cli_types import (
-    LazyAllocFile,
-    LazyAllocJson,
-    LazyAllocStr,
+    LazyAlloc,
     TransitionToolInput,
 )
 
@@ -30,28 +27,13 @@ def dump_files_to_directory(output_path: Path, files: Dict[str, Any]) -> None:
         if rel_path:
             os.makedirs(output_path / rel_path, exist_ok=True)
         file_path = output_path / file_rel_path
-        if (
-            isinstance(file_contents, LazyAllocFile)
-            and Path(file_contents.raw).exists()
-        ):
-            shutil.copyfile(file_contents.raw, file_path)
-        elif isinstance(file_contents, LazyAllocFile):
-            # Backing temp dir was cleaned up after a previous `.get()`
-            # (e.g. chained-block t8n on the next block); fall back to
-            # the cached Alloc so debug dumps still capture the input.
-            file_path.write_text(
-                file_contents.get().model_dump_json(
-                    indent=4, exclude_none=True, by_alias=True
-                )
+        if isinstance(file_contents, LazyAlloc):
+            file_contents.serialize_to_file(
+                file_path, indent=4, exclude_none=True, by_alias=True
             )
         else:
             with open(file_path, "w") as f:
-                if isinstance(file_contents, (LazyAllocStr, LazyAllocJson)):
-                    if isinstance(file_contents, LazyAllocJson):
-                        dump(file_contents.raw, f, ensure_ascii=True, indent=4)
-                    else:
-                        f.write(file_contents.raw)
-                elif isinstance(
+                if isinstance(
                     file_contents, (BaseModel, RootModel, TransitionToolInput)
                 ):
                     f.write(

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -183,7 +183,7 @@ def test_evm_t8n(
                 blob_schedule=Berlin.blob_schedule(),
             ),
         )
-        assert to_json(t8n_output.alloc.get()) == expected.get("alloc")
+        assert to_json(t8n_output.alloc.materialize()) == expected.get("alloc")
         t8n_result = to_json(t8n_output.result)
         if isinstance(default_t8n, ExecutionSpecsTransitionTool):
             # The expected output was generated with geth, instead of deleting

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
@@ -133,7 +133,7 @@ TEST_ALLOC_STATE_ROOT = TEST_ALLOC.state_root()
 def test_lazy_alloc(ty: Type[LazyAlloc], raw: Any) -> None:
     """Test LazyAlloc types."""
     lazy_instance = ty(raw=raw, _state_root=TEST_ALLOC_STATE_ROOT)
-    assert lazy_instance.get() == TEST_ALLOC
+    assert lazy_instance.materialize() == TEST_ALLOC
     assert lazy_instance.state_root() == TEST_ALLOC_STATE_ROOT
 
 
@@ -144,7 +144,7 @@ def test_lazy_alloc_file(tmp_path: Path) -> None:
     lazy_instance = LazyAllocFile(
         raw=alloc_path, _state_root=TEST_ALLOC_STATE_ROOT
     )
-    assert lazy_instance.get() == TEST_ALLOC
+    assert lazy_instance.materialize() == TEST_ALLOC
     assert lazy_instance.state_root() == TEST_ALLOC_STATE_ROOT
 
 
@@ -169,7 +169,7 @@ def test_lazy_alloc_file_handles_mixed_entries(tmp_path: Path) -> None:
     alloc_path = tmp_path / "alloc.json"
     alloc_path.write_text(alloc.model_dump_json())
     lazy_instance = LazyAllocFile(raw=alloc_path, _state_root=state_root)
-    assert lazy_instance.get() == alloc
+    assert lazy_instance.materialize() == alloc
     assert lazy_instance.state_root() == state_root
 
 
@@ -202,7 +202,7 @@ def test_model_validate_files_uses_lazy_alloc_file(tmp_path: Path) -> None:
 
     assert isinstance(output.alloc, LazyAllocFile)
     assert output.alloc.raw == alloc_path
-    assert output.alloc.get() == TEST_ALLOC
+    assert output.alloc.materialize() == TEST_ALLOC
 
 
 def test_transition_tool_input_serializes_lazy_alloc_file(
@@ -241,7 +241,7 @@ def test_to_files_copies_chained_lazy_alloc_file_without_serialize(
     """
     Chained-block handoff: `to_files` should copy the backing alloc file
     byte-for-byte rather than round-tripping through
-    `LazyAllocFile.get().model_dump_json()`. Verified by populating the
+    `LazyAllocFile.materialize().model_dump_json()`. Verified by populating the
     file with bytes that don't match what pydantic would re-emit and
     asserting those exact bytes survive the dump.
     """
@@ -313,7 +313,7 @@ def test_lazy_alloc_file_keepalive_pins_temp_dir() -> None:
     # Releasing our handle leaves the file alive via the keepalive on lazy.
     del keep
     assert alloc_path.exists()
-    assert lazy.get() == TEST_ALLOC
+    assert lazy.materialize() == TEST_ALLOC
 
     # Dropping the LazyAllocFile drops the keepalive; TemporaryDirectory's
     # finalizer wipes the directory. PyPy doesn't refcount, so trigger GC
@@ -351,10 +351,10 @@ def test_dump_files_to_directory_lazy_alloc_file_after_backing_removed(
 ) -> None:
     """
     On chained blocks, the previous block's t8n temp dir is cleaned up after
-    its alloc is materialized via ``.get()``. The resulting ``LazyAllocFile``
-    still carries a now-stale ``.raw`` path. Debug dumps must fall back to
-    re-serializing the cached ``Alloc`` instead of attempting to copy the
-    missing backing file.
+    its alloc is materialized via ``.materialize()``. The resulting
+    ``LazyAllocFile`` still carries a now-stale ``.raw`` path. Debug dumps must
+    fall back to re-serializing the cached ``Alloc`` instead of attempting to
+    copy the missing backing file.
     """
     from execution_testing.client_clis.file_utils import (
         dump_files_to_directory,
@@ -363,7 +363,7 @@ def test_dump_files_to_directory_lazy_alloc_file_after_backing_removed(
     source = tmp_path / "source_alloc.json"
     source.write_text(TEST_ALLOC.model_dump_json())
     lazy = LazyAllocFile(raw=source, _state_root=TEST_ALLOC_STATE_ROOT)
-    lazy.get()
+    lazy.materialize()
     source.unlink()
 
     dump_dir = tmp_path / "dump"
@@ -397,7 +397,7 @@ def test_lazy_alloc_file_malformed_json_raises(
     lazy = LazyAllocFile(raw=alloc_path, _state_root=TEST_ALLOC_STATE_ROOT)
 
     with pytest.raises(ijson.common.IncompleteJSONError):
-        lazy.get()
+        lazy.materialize()
 
 
 @pytest.mark.parametrize(
@@ -422,7 +422,7 @@ def test_lazy_alloc_file_non_object_top_level_raises(
     lazy = LazyAllocFile(raw=alloc_path, _state_root=TEST_ALLOC_STATE_ROOT)
 
     with pytest.raises(ValueError, match="Expected JSON object"):
-        lazy.get()
+        lazy.materialize()
 
 
 def test_lazy_alloc_file_empty_object_yields_empty_alloc(
@@ -436,7 +436,7 @@ def test_lazy_alloc_file_empty_object_yields_empty_alloc(
     alloc_path.write_bytes(b"{}")
     lazy = LazyAllocFile(raw=alloc_path, _state_root=TEST_ALLOC_STATE_ROOT)
 
-    assert lazy.get() == Alloc.model_validate({})
+    assert lazy.materialize() == Alloc.model_validate({})
 
 
 def _output_with_opcode_count(counts: dict) -> TransitionToolOutput:

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -169,7 +169,7 @@ class OutputCache:
             # Without this, every cached subcall would retain its own
             # `output/alloc.json` on disk for the test's lifetime - O(N) for
             # an N-block chained test.
-            alloc.get()
+            alloc.materialize()
             alloc._keepalive = None
         self._cache[subkey] = value
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1084,7 +1084,7 @@ class BlockchainTest(BaseTest):
             print_traces(t8n.get_traces())
             pprint(transition_tool_output.result)
             pprint(previous_alloc)
-            pprint(transition_tool_output.alloc.get())
+            pprint(transition_tool_output.alloc.materialize())
             raise e
 
         if len(rejected_txs) > 0 and block.exception is None:
@@ -1179,13 +1179,13 @@ class BlockchainTest(BaseTest):
             if block.expected_post_state:
                 self.verify_post_state(
                     t8n,
-                    t8n_state=alloc.get()
+                    t8n_state=alloc.materialize()
                     if isinstance(alloc, LazyAlloc)
                     else alloc,
                     expected_state=block.expected_post_state,
                 )
         self.check_exception_test(exception=invalid_blocks > 0)
-        alloc = alloc.get() if isinstance(alloc, LazyAlloc) else alloc
+        alloc = alloc.materialize() if isinstance(alloc, LazyAlloc) else alloc
         self.verify_post_state(t8n, t8n_state=alloc)
         fixture = BlockchainFixture(
             fork=self.fork,
@@ -1269,7 +1269,7 @@ class BlockchainTest(BaseTest):
             if block.expected_post_state:
                 self.verify_post_state(
                     t8n,
-                    t8n_state=alloc.get()
+                    t8n_state=alloc.materialize()
                     if isinstance(alloc, LazyAlloc)
                     else alloc,
                     expected_state=block.expected_post_state,
@@ -1283,7 +1283,7 @@ class BlockchainTest(BaseTest):
             " The framework should never try to execute this test case."
         )
 
-        alloc = alloc.get() if isinstance(alloc, LazyAlloc) else alloc
+        alloc = alloc.materialize() if isinstance(alloc, LazyAlloc) else alloc
         self.verify_post_state(t8n, t8n_state=alloc)
 
         # Create base fixture data, common to all fixture formats

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -167,7 +167,7 @@ class StateTest(BaseTest):
                 f"Traces are not equivalent (gas_limit={current_gas_limit})"
             )
             return False
-        modified_tool_alloc = modified_tool_output.alloc.get()
+        modified_tool_alloc = modified_tool_output.alloc.materialize()
         try:
             self.post.verify_post_alloc(modified_tool_alloc)
         except Exception as e:
@@ -378,7 +378,7 @@ class StateTest(BaseTest):
             ),
             slow_request=self.is_tx_gas_heavy_test,
         )
-        output_alloc = transition_tool_output.alloc.get()
+        output_alloc = transition_tool_output.alloc.materialize()
 
         try:
             self.post.verify_post_alloc(output_alloc)
@@ -408,7 +408,7 @@ class StateTest(BaseTest):
                 self.operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
             )
             base_tool_output = transition_tool_output
-            base_tool_alloc = base_tool_output.alloc.get()
+            base_tool_alloc = base_tool_output.alloc.materialize()
             base_tool_result = base_tool_output.result
 
             assert base_tool_result.traces is not None, "Traces not found."

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -222,7 +222,7 @@ class T8N(Load):
         # to remain unchanged when ``block.exception`` is set.
         input_alloc = t8n_data.alloc
         if isinstance(input_alloc, LazyAlloc):
-            input_alloc = input_alloc.get()
+            input_alloc = input_alloc.materialize()
         self.alloc = input_alloc.model_copy(deep=True)
         self.env = t8n_data.env
         self.txs = list(t8n_data.txs)

--- a/src/ethereum_spec_tools/evm_tools/t8n/cli.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/cli.py
@@ -390,7 +390,9 @@ def write_t8n_outputs(
     out_file: TextIO,
 ) -> None:
     """Serialise the t8n output + opcode counts per ``--output.*``."""
-    json_state = output.alloc.get().model_dump(mode="json", by_alias=True)
+    json_state = output.alloc.materialize().model_dump(
+        mode="json", by_alias=True
+    )
     json_result = output.result.model_dump(
         mode="json", by_alias=True, exclude_none=True
     )


### PR DESCRIPTION
### Description

- Rename `LazyAlloc.get()` to `LazyAlloc.materialize()` since it clashed in spirit with `Alloc.get(address)` (a mapping accessor with an incompatible  signature).
- Give `LazyAlloc` a serialization protocol: `serialize() -> str` and `serialize_to_file(path)` (delegates to serialize, except `LazyAllocFile`, which keeps a `shutil.copyfile` byte-copy fast path).